### PR TITLE
Key bindings conflict with Flycheck

### DIFF
--- a/launch.el
+++ b/launch.el
@@ -160,8 +160,8 @@ the mode if ARG is omitted or nil.
 
 Turning on launch-mode will add keybindings for `launch-file' and
 `launch-directory'."
-  :keymap '(("\C-c!!" . launch-file)
-            ("\C-c!d" . launch-directory)))
+  :keymap '(("\C-c&&" . launch-file)
+            ("\C-c&d" . launch-directory)))
 
 ;;;###autoload
 (defun turn-on-launch-mode ()
@@ -208,8 +208,8 @@ can be produced by `dired-get-marked-files', for example."
 ;; Provide a special keymap for dired-mode
 (defvar launch-mode-dired-map
   (easy-mmode-define-keymap
-   '(("\C-c!!" . launch-files-dired)
-     ("\C-c!d" . launch-directory-dired))
+   '(("\C-c&&" . launch-files-dired)
+     ("\C-c&d" . launch-directory-dired))
    nil
    nil
    '(:inherit launch-mode-map))
@@ -254,8 +254,8 @@ can be produced by `vc-dir-marked-files', for example."
 ;; Provide a special keymap for vc-dir-mode
 (defvar launch-mode-vc-dir-map
   (easy-mmode-define-keymap
-   '(("\C-c!!" . launch-files-vc-dir)
-     ("\C-c!d" . launch-directory-vc-dir))
+   '(("\C-c&&" . launch-files-vc-dir)
+     ("\C-c&d" . launch-directory-vc-dir))
    nil
    nil
    '(:inherit launch-mode-map))


### PR DESCRIPTION
Your key bindings at `C-c !` conflict with [Flycheck](https://github.com/lunaryorn/flycheck), which uses `C-c !`, too.

Would you mind to change your bindings to `C-c &`?

**Disclaimer:**  I am the author of Flycheck and obviously biased :), so please just choose to ignore this report if you want to.
